### PR TITLE
Refactor users using default_scope and test

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,7 +1,8 @@
 class StaticPagesController < ApplicationController
   before_action :logged_in_user, only: :hub
   def index
-    @users = User.order_by_points.first(10)
+    # Users are now by default ordered by points. Check user.rb.
+    @users = User.first(10)
   end
   
   def hub

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,9 +4,8 @@ class UsersController < ApplicationController
   before_action :correct_user_or_admin,   only: [:edit, :update, :destroy]
   
   def index
-    # Change order of users.
-    # User.joins(:user => :player).select("users.id").group("users.id").order("player.experience DESC")
-    @users = User.order_by_points.paginate(page: params[:page], :per_page => User.per_page)
+    # Users are now by default ordered by points. Check user.rb.
+    @users = User.paginate(page: params[:page], :per_page => User.per_page)
   end
   
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,9 @@ class User < ActiveRecord::Base
   attr_accessor :remember_token
   has_one :player, dependent: :destroy # Relations to players table
   
+  # This makes it so that by default the users will be ordered by points.
+  default_scope -> { includes(:player).order("players.level - players.deaths DESC, players.experience DESC") }
+  
   before_save {
     # Ensures entries are unique in the database.
     username.downcase!
@@ -48,10 +51,5 @@ class User < ActiveRecord::Base
   # Specifies the amount of users per page. Goes in unison with will_paginate.
   def per_page
     30
-  end
-  
-  # Rankings for users
-  def self.order_by_points
-    includes(:player).order("players.level - players.deaths DESC, players.experience DESC")
   end
 end

--- a/test/fixtures/players.yml
+++ b/test/fixtures/players.yml
@@ -23,7 +23,7 @@ archer:
   items: {}
 
 # This player should be at the top of the rankings
-# Make sure the level is equal to player4, but experience is higher
+# Make sure the level is equal to malory, but experience is higher
 lana:
   user: lana
   health: 50

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -6,7 +6,6 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     @non_admin = users(:archer)
     @first_rank = users(:lana)
     @second_rank = users(:malory)
-    @user = users(:user_14)
   end
   
   test "index including pagination and delete links and rankings" do
@@ -18,6 +17,7 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     first_page_of_users = User.paginate(page: 1)
     all = User.all
     assert_equal all.index(@first_rank), 0 # first position
+    assert_equal all.index(@second_rank), 1 # second position
     first_page_of_users.each do |user|
       assert_select 'a[href=?]', user_path(user), text: user.username
       assert_select 'td', "Points: " + (user.player.level - user.player.deaths).to_s , count: User.count('id')

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -5,6 +5,8 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     @admin     = users(:michael)
     @non_admin = users(:archer)
     @first_rank = users(:lana)
+    @second_rank = users(:malory)
+    @user = users(:user_14)
   end
   
   test "index including pagination and delete links and rankings" do
@@ -14,8 +16,8 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     get users_path
     assert_select 'div.pagination'
     first_page_of_users = User.paginate(page: 1)
-    # Check if first_rank is in the first page.
-    assert_select 'a[href=?]', user_path(@first_rank), text: @first_rank.username
+    all = User.all
+    assert_equal all.index(@first_rank), 0 # first position
     first_page_of_users.each do |user|
       assert_select 'a[href=?]', user_path(user), text: user.username
       assert_select 'td', "Points: " + (user.player.level - user.player.deaths).to_s , count: User.count('id')


### PR DESCRIPTION
I made it so that users are now by default ordered by points. This means when you do a Users.all, the users will be pulled from the database ordered by points. @kelvin94 this may be important for you, since you worked on the rankings table.